### PR TITLE
Add mobile touch camera controls and planetary orbit rendering

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -51,6 +51,9 @@
 
             /* Prevent inline-canvas whitespace affecting layout. */
             display: block;
+
+            /* Ensure touch gestures are handled by the canvas. */
+            touch-action: none;
         }
         #astorb3dCanvas:focus
         {


### PR DESCRIPTION
### Motivation
- Enable comfortable mobile interaction by adding touch-based camera rotation and pinch-to-zoom so the scene is usable on phones and tablets.
- Provide visual context for relative scales by drawing accurate elliptical orbit paths for the major planets using their orbital elements.

### Description
- Add touch handling in `astorb.setupCameraControls` to support single-finger drag for rotation and two-finger pinch for zoom, and set `touch-action: none` on the canvas in `astorb3d.html`.
- Introduce `astorb.planetOrbits` data and `astorb.initPlanetOrbits` to generate orbit vertex buffers from orbital elements and upload them to `astorb.planetOrbitBuffer`.
- Add `astorb.configureAttributePointers` to centralize guarded `gl.vertexAttribPointer` setup and replace inline attribute setup for the asteroid buffer and orbit buffer.
- Render planet orbits before asteroids by binding `astorb.planetOrbitBuffer` and drawing `gl.LINE_STRIP` for each orbit, then restore asteroid buffer and draw points; update status/control text to reference pinch gestures.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` and ran a Playwright script to load `astorb3d.html` and capture a screenshot; the screenshot artifact `artifacts/astorb3d-orbits.png` was produced successfully.
- No unit tests were added or run for this change (visual/manual verification via the generated screenshot was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a781624548329aea85e15093c0ca4)