### PR TITLE
Add stats.js performance overlay

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -140,6 +140,7 @@
 <!-- <script src="scripts/js/libs/sylvester.src.js"></script> -->
 <!-- <script src="scripts/js/libs/glUtils.js"></script> -->
 <script src="scripts/js/libs/gl-matrix-min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/stats.js/latest/stats.min.js"></script>
 <script src="scripts/js/astorb3d.js"></script>
 <script type="x-shader/x-vertex" id="shader-vs">
     precision mediump float; // or lowp

--- a/scripts/js/astorb3d.js
+++ b/scripts/js/astorb3d.js
@@ -125,6 +125,7 @@ astorb.onLoadBody = function()
                 }
 
                 astorb.setupTimeControls();
+                astorb.initStats();
                 astorb.loadAstorbData();
             }
         }
@@ -857,6 +858,21 @@ astorb.setupTimeControls = function()
     astorb.refreshTimeControls();
 };
 
+astorb.stats = null;
+astorb.initStats = function()
+{
+    if (typeof Stats === 'undefined') return;
+
+    var stats = new Stats();
+    stats.showPanel(0);
+    stats.dom.style.position = 'fixed';
+    stats.dom.style.top = '0';
+    stats.dom.style.right = '0';
+    stats.dom.style.left = 'auto';
+    document.body.appendChild(stats.dom);
+    astorb.stats = stats;
+};
+
 astorb.refreshTimeControls = function()
 {
     var pauseButton = document.getElementById('pauseButton');
@@ -903,6 +919,12 @@ astorb.animate = function(timestamp)
     var gl = astorb.gl;
     var asteroidCount = astorb.asteroidCount;
     var time = astorb.time;
+    var stats = astorb.stats;
+
+    if (stats)
+    {
+        stats.begin();
+    }
 
     // Keep buffer sized even if layout changes during animation.
     astorb.resizeWebGL();
@@ -993,6 +1015,11 @@ astorb.animate = function(timestamp)
         astorb.firstFrameRendered = true;
         window.__astorbFirstFrameRendered = true;
         document.dispatchEvent(new CustomEvent('astorb:first-frame'));
+    }
+
+    if (stats)
+    {
+        stats.end();
     }
 
     requestAnimationFrame(astorb.animate);


### PR DESCRIPTION
### Motivation
- Provide a simple real-time performance overlay (FPS and timing) to aid debugging and performance tuning of the WebGL scene.
- Make it easy to observe frame timing without external profiling tools.
- Keep integration lightweight by using the popular `stats.js` library from a CDN.

### Description
- Load the latest `stats.js` from CDN by adding the script tag to `astorb3d.html`.
- Add `astorb.initStats` to create and style the overlay, and call it during startup from `astorb.onLoadBody`.
- Integrate `stats.begin()` / `stats.end()` into the render loop (`astorb.animate`) so timings are measured each frame and pin the overlay to the top-right of the page.
- Changes made in `astorb3d.html` and `scripts/js/astorb3d.js`.

### Testing
- Launched a local HTTP server using `python -m http.server 8000` and verified the page loads successfully.
- Ran a Playwright script to open `http://127.0.0.1:8000/astorb3d.html` and captured a screenshot `artifacts/stats-overlay.png` showing the overlay present on the page.
- Confirmed the changes staged and committed locally with a descriptive commit message.
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a8a8884108329bf2d82c0da2d18df)