### PR TITLE
Remap reset to 0/O, format asteroid counts with percent, and brighten fragment colors

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -223,7 +223,12 @@
         float r = 0.5 + 0.5 * x / max(dist, 0.1);
         float g = 0.5 + 0.5 * y / max(dist, 0.1);
         float b = 0.5 + 0.5 * z / max(dist, 0.1);
-        gl_FragColor = vec4(r, g, b, 1.0);
+        vec3 color = vec3(r, g, b);
+        color = pow(color, vec3(0.75));
+        float luma = dot(color, vec3(0.2126, 0.7152, 0.0722));
+        color = mix(vec3(luma), color, 1.1);
+        color = clamp(color, 0.0, 1.0);
+        gl_FragColor = vec4(color, 1.0);
     }
 </script>
 <script type="x-shader/x-vertex" id="shader-bodies-vs">

--- a/scripts/js/astorb3d.js
+++ b/scripts/js/astorb3d.js
@@ -11,6 +11,25 @@
 
 var astorb = astorb || {};
 
+astorb.formatNumber = function(value)
+{
+    if (value === null || value === undefined)
+    {
+        return "--";
+    }
+    return Number(value).toLocaleString('en-US');
+};
+
+astorb.formatAsteroidPercent = function(current, total)
+{
+    if (!total)
+    {
+        return "0%";
+    }
+    var percent = (current / total) * 100;
+    return percent.toFixed(1) + "%";
+};
+
 // Resize canvas drawing buffer + viewport to match CSS size.
 astorb.resizeWebGL = function()
 {
@@ -806,14 +825,11 @@ astorb.setupCameraControls = function(canvas)
                 astorb.refreshTimeControls();
                 event.preventDefault();
                 break;
-            case 'r':  // Reset view
-            case 'R':
-                camera.rotationX = 0.5;
-                camera.rotationY = 0;
-                camera.distance = 8.0;
+            case '0':  // Reset time to 0
+            case 'o':
+            case 'O':
                 time.simTime = 0;
-                astorb.updateViewMatrix();
-                astorb.log("View reset", "blue");
+                astorb.log("Time reset to 0", "blue");
                 event.preventDefault();
                 break;
         }
@@ -822,7 +838,7 @@ astorb.setupCameraControls = function(canvas)
     canvas.addEventListener('keydown', handleKeydown);
     window.addEventListener('keydown', handleKeydown);
 
-    astorb.log("Controls: Drag to rotate, Scroll/pinch to zoom, Space=pause, Up/Down=speed, R=reset", "green");
+    astorb.log("Controls: Drag to rotate, Scroll/pinch to zoom, Space=pause, Up/Down=speed, 0/O=reset time", "green");
     astorb.log("Click on canvas first to enable keyboard controls", "green");
 };
 
@@ -875,7 +891,7 @@ astorb.setupAsteroidControls = function()
             var current = astorb.asteroidDrawCount || total;
             var nextCount = Math.max(1, Math.floor(current / 2));
             astorb.asteroidDrawCount = nextCount;
-            astorb.log("Asteroid draw count: " + nextCount + " / " + total, "blue");
+            astorb.log("Asteroid draw count: " + astorb.formatNumber(nextCount) + " / " + astorb.formatNumber(total), "blue");
             astorb.refreshAsteroidControls();
         });
     }
@@ -888,7 +904,7 @@ astorb.setupAsteroidControls = function()
             var current = astorb.asteroidDrawCount || total;
             var nextCount = Math.min(total, current * 2);
             astorb.asteroidDrawCount = nextCount;
-            astorb.log("Asteroid draw count: " + nextCount + " / " + total, "blue");
+            astorb.log("Asteroid draw count: " + astorb.formatNumber(nextCount) + " / " + astorb.formatNumber(total), "blue");
             astorb.refreshAsteroidControls();
         });
     }
@@ -939,7 +955,9 @@ astorb.refreshAsteroidControls = function()
     {
         if (total)
         {
-            asteroidCountLabel.textContent = "Asteroids: " + current + " / " + total;
+            var percent = astorb.formatAsteroidPercent(current, total);
+            asteroidCountLabel.textContent = "Asteroids: " + astorb.formatNumber(current) + " / " +
+                astorb.formatNumber(total) + " (" + percent + ")";
         }
         else
         {
@@ -1027,11 +1045,13 @@ astorb.animate = function(timestamp)
         if (statusDiv) {
             var years = time.simTime / (365.25 * 24 * 3600);  // Convert seconds to years
             var pauseStatus = time.paused ? "[PAUSED]" : "[RUNNING]";
+            var percent = astorb.formatAsteroidPercent(asteroidDrawCount, asteroidCount);
             statusDiv.innerHTML = pauseStatus + " Time: " + years.toFixed(2) + " years | " +
-                "Asteroids: " + asteroidDrawCount + " / " + asteroidCount + " | " +
+                "Asteroids: " + astorb.formatNumber(asteroidDrawCount) + " / " + astorb.formatNumber(asteroidCount) +
+                " (" + percent + ") | " +
                 "Camera: distance=" + astorb.camera.distance.toFixed(1) + " AU | " +
                 "Speed: " + time.timeScale.toExponential(1) + "x | " +
-                "Controls: Drag=rotate, Scroll/pinch=zoom, Space=pause, Up/Down=speed, R=reset";
+                "Controls: Drag=rotate, Scroll/pinch=zoom, Space=pause, Up/Down=speed, 0/O=reset time";
         }
     }
 


### PR DESCRIPTION
### Motivation
- Avoid overriding the browser's default refresh shortcut by removing the `R` reset binding and providing alternative keys.
- Make asteroid counts human-friendly with proper comma grouping and show the percentage being rendered.
- Improve visual consistency of asteroid colors so blues/purples are not too dark on a black background.

### Description
- Changed keyboard handling in `scripts/js/astorb3d.js` to use `0`, `o`, and `O` to reset simulation time and removed the camera/view reset behavior.
- Added `astorb.formatNumber` and `astorb.formatAsteroidPercent` and used them to format log messages, the `#asteroidCountLabel`, and the status display with percent rendered. 
- Updated control hint strings to reflect the new reset keys in `scripts/js/astorb3d.js`.
- Adjusted the asteroid fragment shader in `astorb3d.html` to apply a simple perceptual correction (`pow` + luma mix) to brighten and normalize perceived vibrance across hues.

### Testing
- Served the site with `python3 -m http.server` and ran a Playwright script to load `astorb3d.html` and capture a screenshot, which completed successfully and produced an artifact. 
- No unit tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab75e65688329a84fc2023e0b61ae)