### PR TITLE
Add depth buffer toggle for 3D rendering

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -132,6 +132,7 @@
     <button id="fastButton" type="button">Speed Up</button>
     <button id="asteroidHalfButton" type="button">Half Asteroids</button>
     <button id="asteroidDoubleButton" type="button">Double Asteroids</button>
+    <button id="depthBufferButton" type="button">Depth: --</button>
     <span id="timeScaleLabel">Speed: --</span>
     <span id="asteroidCountLabel">Asteroids: --</span>
 </div>

--- a/scripts/js/astorb3d.js
+++ b/scripts/js/astorb3d.js
@@ -114,6 +114,7 @@ astorb.log("astorb3d.js", "black");
 astorb.log("by John W. Shaffstall", "black");
 
 astorb.canvasId = "astorb3dCanvas";
+astorb.depthBufferEnabled = true;
 astorb.onLoadBody = function()
 {
     var canvas = document.getElementById(astorb.canvasId);
@@ -123,8 +124,9 @@ astorb.onLoadBody = function()
 
         try
         {
-            gl = canvas.getContext("webgl", {antialias:false})
-                || canvas.getContext("experimental-webgl", {antialias:false});
+            var contextOptions = {antialias: false, depth: true};
+            gl = canvas.getContext("webgl", contextOptions)
+                || canvas.getContext("experimental-webgl", contextOptions);
             var initWebGLSuccess = astorb.initWebGL(gl, canvas);
             if (initWebGLSuccess)
             {
@@ -145,6 +147,7 @@ astorb.onLoadBody = function()
 
                 astorb.setupTimeControls();
                 astorb.setupAsteroidControls();
+                astorb.setupDepthBufferControls();
                 astorb.initStats();
                 astorb.loadAstorbData();
             }
@@ -168,7 +171,7 @@ astorb.initWebGL = function(gl, canvas)
     if (gl && canvas)
     {
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
-        gl.disable(gl.DEPTH_TEST);
+        astorb.applyDepthBufferState();
         // gl.enable(gl.BLEND);
         gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -188,6 +191,25 @@ astorb.initWebGL = function(gl, canvas)
     }
 
     return success;
+};
+
+astorb.applyDepthBufferState = function()
+{
+    var gl = astorb.gl;
+    if (!gl) return;
+
+    if (astorb.depthBufferEnabled)
+    {
+        gl.enable(gl.DEPTH_TEST);
+        gl.depthFunc(gl.LEQUAL);
+        gl.depthMask(true);
+        gl.clearDepth(1.0);
+    }
+    else
+    {
+        gl.disable(gl.DEPTH_TEST);
+        gl.depthMask(false);
+    }
 };
 
 astorb.initShaders = function(gl)
@@ -912,6 +934,23 @@ astorb.setupAsteroidControls = function()
     astorb.refreshAsteroidControls();
 };
 
+astorb.setupDepthBufferControls = function()
+{
+    var depthButton = document.getElementById('depthBufferButton');
+
+    if (depthButton)
+    {
+        depthButton.addEventListener('click', function() {
+            astorb.depthBufferEnabled = !astorb.depthBufferEnabled;
+            astorb.applyDepthBufferState();
+            astorb.refreshDepthBufferControls();
+            astorb.log("Depth buffer " + (astorb.depthBufferEnabled ? "enabled" : "disabled"), "blue");
+        });
+    }
+
+    astorb.refreshDepthBufferControls();
+};
+
 astorb.stats = null;
 astorb.initStats = function()
 {
@@ -973,6 +1012,16 @@ astorb.refreshAsteroidControls = function()
     if (doubleButton)
     {
         doubleButton.disabled = !total || current >= total;
+    }
+};
+
+astorb.refreshDepthBufferControls = function()
+{
+    var depthButton = document.getElementById('depthBufferButton');
+
+    if (depthButton)
+    {
+        depthButton.textContent = "Depth: " + (astorb.depthBufferEnabled ? "On" : "Off");
     }
 };
 


### PR DESCRIPTION
### Motivation

- Provide a runtime feature toggle so nearer objects (asteroids, orbit lines, bodies) can be rendered on top of farther ones using the depth buffer.
- Allow users to enable/disable depth testing without reloading the page or changing code.

### Description

- Add a `Depth: On/Off` button to the control bar in `astorb3d.html` and a `astorb.depthBufferEnabled` flag defaulting to `true`.
- Request a depth buffer when creating the WebGL context by passing `{ depth: true }` in the context options and replace the previous hard disable of depth testing with `astorb.applyDepthBufferState()`.
- Implement `astorb.applyDepthBufferState()` to enable/disable `gl.DEPTH_TEST`, set `gl.depthFunc`, `gl.depthMask`, and `gl.clearDepth` as appropriate.
- Add `setupDepthBufferControls()` and `refreshDepthBufferControls()` to wire the UI button to toggle `astorb.depthBufferEnabled` and update the button label.

### Testing

- Started a local HTTP server with `python -m http.server` and loaded `astorb3d.html` in a headless browser to exercise the page (server start succeeded).
- Ran a Playwright-based script that waited for `window.__astorbDataLoaded === true && window.__astorbFirstFrameRendered === true` and captured a screenshot to verify the page loads and the first frame renders (screenshot capture succeeded).
- No unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695abde64b708329bb9fe3eaf6b426be)