### PR TITLE
Prevent double-tap zoom and reduce mobile control sizing

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>astorb 3d</title>
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <style>
         html, body
         {
@@ -16,6 +16,9 @@
             font-family: monospace;
             background-color: white;
             color: black;
+
+            /* Avoid double-tap zoom while tapping controls. */
+            touch-action: manipulation;
 
             /* Let the canvas take the remaining height. */
             display: flex;
@@ -87,6 +90,7 @@
             font-size: 14px;
             cursor: pointer;
             min-width: 90px;
+            touch-action: manipulation;
         }
         #controlBar button:active
         {
@@ -99,11 +103,17 @@
         }
         @media (max-width: 640px)
         {
+            #controlBar
+            {
+                gap: 4px;
+                padding: 4px 0;
+            }
             #controlBar button
             {
-                flex: 1 1 120px;
-                font-size: 16px;
-                padding: 10px 16px;
+                flex: 1 1 96px;
+                font-size: 12px;
+                padding: 6px 8px;
+                min-width: 0;
             }
         }
         #astorbLog


### PR DESCRIPTION
### Motivation
- Prevent accidental double-tap zoom on mobile so control taps register immediately.  
- Give the canvas more visible area on small screens by reducing control sizing and spacing.  
- Ensure touch gestures on controls are handled reliably by the page.  

### Description
- Updated `astorb3d.html` `meta` viewport to `width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no`.  
- Added `touch-action: manipulation` to `body` and `#controlBar button` to avoid double-tap zoom and improve touch handling.  
- Tightened mobile CSS in `@media (max-width: 640px)` by reducing `#controlBar` gap/padding and shrinking button `flex`, `font-size`, `padding`, and `min-width` so the canvas can occupy more space.  

### Testing
- Launched a local server with `python -m http.server` and opened the page in an automated Playwright run using a mobile viewport (390×844).  
- Playwright loaded `astorb3d.html` and produced a screenshot at `artifacts/astorb3d-mobile.png`, confirming the updated mobile layout.  
- No unit tests were required for these static HTML/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aea98faa4832996d75a62f7d83814)