### PR TITLE
Fix touch horizontal camera rotation on mobile

### DIFF
--- a/scripts/js/astorb3d.js
+++ b/scripts/js/astorb3d.js
@@ -806,7 +806,7 @@ astorb.setupCameraControls = function(canvas)
             var deltaY = touch.clientY - touchState.lastY;
 
             var rotateSpeed = 0.005;
-            camera.azimuth -= deltaX * rotateSpeed;
+            camera.azimuth += deltaX * rotateSpeed;
             camera.elevation += deltaY * rotateSpeed;
 
             var maxElev = camera.maxElevationRadians || (80.0 * Math.PI / 180.0);


### PR DESCRIPTION
### Motivation
- Mobile single-finger horizontal drag produced the opposite azimuth direction compared to desktop mouse drags, causing a reversed feel on touch devices.
- The goal is to make touch rotation match the existing mouse rotation behavior for a consistent control scheme.

### Description
- Updated touch handling in `scripts/js/astorb3d.js` to change the azimuth sign so touch horizontal drags rotate the same way as mouse drags by replacing `camera.azimuth -= deltaX * rotateSpeed;` with `camera.azimuth += deltaX * rotateSpeed;`.
- The change occurs in the `touchmove` handler for single-touch rotation and continues to clamp `camera.elevation` and call `astorb.updateViewMatrix()` after applying deltas.

### Testing
- No automated tests were run for this change.
- The change was committed with the message `Fix touch horizontal camera rotation`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af022637083299baba3e5b52f612c)