### PR TITLE
Adjust mobile header safe area and simplify status display

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -29,7 +29,7 @@
             box-sizing: border-box;
 
             /* Internal spacing without affecting flex sizing like margins can. */
-            padding: 4px;
+            padding: calc(4px + env(safe-area-inset-top)) 4px 4px 4px;
 
             /* Allow children to shrink instead of overflowing. */
             min-height: 0;

--- a/scripts/js/astorb3d.js
+++ b/scripts/js/astorb3d.js
@@ -1236,9 +1236,7 @@ astorb.animate = function(timestamp)
             statusDiv.innerHTML = pauseStatus + " Time: " + years.toFixed(2) + " years | " +
                 "Asteroids: " + astorb.formatNumber(asteroidDrawCount) + " / " + astorb.formatNumber(asteroidCount) +
                 " (" + percent + ") | " +
-                "Camera: distance=" + astorb.camera.distance.toFixed(1) + " AU | " +
-                "Speed: " + time.timeScale.toExponential(1) + "x | " +
-                "Controls: Drag=rotate, Scroll/pinch=zoom, Space=pause, Up/Down=speed, 0/O=reset time";
+                "Speed: " + time.timeScale.toExponential(1) + "x";
         }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the header title is not obscured by the iPhone notch/safe area on mobile by adding top-safe-area padding.
- Reduce clutter in the `#statusDisplay` "RUNNING" line so only essential runtime metrics are shown.

### Description
- Add top safe-area inset to the page padding by changing `body` padding to `padding: calc(4px + env(safe-area-inset-top)) 4px 4px 4px;` in `astorb3d.html`.
- Simplify the status text in `scripts/js/astorb3d.js` by removing camera distance and control hints and leaving only pause state, time, asteroid counts, and speed.
- Modified files: `astorb3d.html` and `scripts/js/astorb3d.js`.

### Testing
- Launched a local HTTP server and captured a mobile (WebKit, 390×844) screenshot with Playwright, producing `artifacts/astorb3d-mobile.png` to verify layout changes.
- No unit or integration test suite was run for these UI-focused, static tweaks.
- Visual verification artifact was generated successfully via the automated browser script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af9a807008329b757ed0fdfce30c1)