### PR TITLE
Render screen-space labels for planet and dwarf planet orbits

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -69,6 +69,29 @@
             flex: 1 1 auto;
             min-height: 0;
         }
+        #labelLayer
+        {
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            z-index: 1;
+            font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+            font-size: 13px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+        .orbit-label
+        {
+            position: absolute;
+            color: #fff;
+            background: rgba(0, 0, 0, 0.65);
+            padding: 2px 6px;
+            border-radius: 8px;
+            white-space: nowrap;
+            letter-spacing: 0.04em;
+            transform: translate(-50%, -50%);
+            text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+        }
         #loadingOverlay
         {
             position: absolute;
@@ -210,6 +233,7 @@
     <canvas id="astorb3dCanvas" tabindex="0">
         Your browser doesn't appear to support the HTML5 <code>&lt;canvas&gt;</code> element.
     </canvas>
+    <div id="labelLayer" aria-hidden="true"></div>
     <div id="loadingOverlay">
         <svg id="loadingProgress" viewBox="0 0 120 120" aria-label="Loading progress">
             <circle class="track" cx="60" cy="60" r="52"></circle>


### PR DESCRIPTION
### Motivation

- Provide visible, legible names for each planet and dwarf planet anchored to the part of their orbit closest to the camera.  
- Make labels remain readable above the WebGL canvas without interfering with input.  
- Compute label positions in screen space so labels follow the current view and hide when off-screen.  

### Description

- Add a label overlay container and styling in `astorb3d.html` (`#labelLayer` and `.orbit-label`) to render text above the canvas.  
- Store the projection matrix and expose the view matrix/camera position in `scripts/js/astorb3d.js` so world -> clip space projection is available (`astorb.projectionMatrix`, `astorb.mvMatrix`, `astorb.cameraWorldPosition`).  
- Implement `astorb.computeOrbitPoint`, `astorb.initOrbitLabels`, and `astorb.updateOrbitLabels` to sample each orbit, find the closest orbit point to the camera, project it to screen space, and position or hide the label accordingly.  
- Wire label initialization into `astorb.initWebGL` and update labels each frame from `astorb.animate` so labels follow camera motion and time updates.  

### Testing

- Launched a local HTTP server and used Playwright to load `astorb3d.html` and capture a screenshot, which completed successfully and produced an artifact.  
- Visually inspected that labels are created and update with the camera (via the captured screenshot).  
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f160d7ef48329b28093810cfa3a84)