### PR TITLE
Add dark theme toggle

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -4,6 +4,40 @@
     <title>astorb 3d</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <style>
+        :root
+        {
+            color-scheme: light;
+            --page-bg: #ffffff;
+            --page-text: #111111;
+            --panel-bg: #f2f2f2;
+            --panel-text: #111111;
+            --button-bg: #222222;
+            --button-text: #ffffff;
+            --button-border: #555555;
+            --status-bg: #333333;
+            --status-text: #00ff00;
+            --log-bg: #e0e0e0;
+            --canvas-bg: #ffe4ec;
+            --label-text: #f1f5f9;
+        }
+
+        body.dark-theme
+        {
+            color-scheme: dark;
+            --page-bg: #0c111a;
+            --page-text: #e2e8f0;
+            --panel-bg: #141b2d;
+            --panel-text: #e2e8f0;
+            --button-bg: #1f2937;
+            --button-text: #f8fafc;
+            --button-border: #3b475a;
+            --status-bg: #0f172a;
+            --status-text: #38f37a;
+            --log-bg: #111827;
+            --canvas-bg: #05070c;
+            --label-text: #f8fafc;
+        }
+
         html, body
         {
             height: 100%;
@@ -14,8 +48,8 @@
         body
         {
             font-family: monospace;
-            background-color: white;
-            color: black;
+            background-color: var(--page-bg);
+            color: var(--page-text);
 
             /* Avoid double-tap zoom while tapping controls. */
             touch-action: manipulation;
@@ -49,7 +83,7 @@
             flex: 1 1 auto;
             min-height: 0;
 
-            background-color: pink;
+            background-color: var(--canvas-bg);
             outline: none;
 
             /* Prevent inline-canvas whitespace affecting layout. */
@@ -84,7 +118,7 @@
         .orbit-label
         {
             position: absolute;
-            color: #fff;
+            color: var(--label-text);
             background: rgba(0, 0, 0, 0.65);
             padding: 2px 6px;
             border-radius: 8px;
@@ -146,8 +180,8 @@
         #statusDisplay
         {
             padding: 5px;
-            background-color: #333;
-            color: #0f0;
+            background-color: var(--status-bg);
+            color: var(--status-text);
             font-size: 12px;
             font-family: monospace;
             flex: 0 0 auto;
@@ -163,15 +197,20 @@
         }
         #controlBar button
         {
-            background-color: #222;
-            color: #fff;
-            border: 1px solid #555;
+            background-color: var(--button-bg);
+            color: var(--button-text);
+            border: 1px solid var(--button-border);
             border-radius: 6px;
             padding: 8px 14px;
             font-size: 14px;
             cursor: pointer;
             min-width: 90px;
             touch-action: manipulation;
+        }
+        #controlBar button:focus-visible
+        {
+            outline: 2px solid #60a5fa;
+            outline-offset: 2px;
         }
         #controlBar button:active
         {
@@ -180,7 +219,7 @@
         #timeScaleLabel
         {
             font-size: 12px;
-            color: #222;
+            color: var(--panel-text);
         }
         @media (max-width: 640px)
         {
@@ -205,13 +244,17 @@
             height: 160px;
             overflow-y: auto;
 
-            background-color: lightgray;
+            background-color: var(--log-bg);
             flex: 0 0 auto;
             min-height: 0;
 
             /* Keep long lines from forcing horizontal growth. */
             white-space: pre-wrap;
             word-break: break-word;
+        }
+        #astorbLog font[color="black"]
+        {
+            color: var(--panel-text);
         }
     </style>
 </head>
@@ -229,6 +272,7 @@
     <button id="motionBlurButton" type="button">Motion Blur: --</button>
     <button id="renderColorButton" type="button">Color: --</button>
     <button id="orbitLabelButton" type="button">Labels: Off</button>
+    <button id="themeToggleButton" type="button">Theme: Light</button>
     <span id="timeScaleLabel">Speed: --</span>
 </div>
 <div id="canvasContainer">

--- a/scripts/js/astorb3d.js
+++ b/scripts/js/astorb3d.js
@@ -219,7 +219,12 @@ astorb.log = function(message, color)
     var logDiv = astorb.logDiv;
     if (logDiv)
     {
-        var coloredMessage = message.fontcolor(color);
+        var resolvedColor = color;
+        if (astorb.isDarkTheme && color === "black")
+        {
+            resolvedColor = "#e2e8f0";
+        }
+        var coloredMessage = message.fontcolor(resolvedColor);
         logDiv.innerHTML = "" + coloredMessage + "</br>" + logDiv.innerHTML;
     }
 };
@@ -232,6 +237,7 @@ astorb.log("Orbital elements: <a href='https://en.wikipedia.org/wiki/Orbital_ele
 astorb.canvasId = "astorb3dCanvas";
 astorb.depthBufferEnabled = true;
 astorb.showOrbitLabels = false;
+astorb.isDarkTheme = false;
 astorb.onLoadBody = function()
 {
     var canvas = document.getElementById(astorb.canvasId);
@@ -268,6 +274,7 @@ astorb.onLoadBody = function()
                 astorb.setupMotionBlurControls();
                 astorb.setupRenderColorControls();
                 astorb.setupOrbitLabelControls();
+                astorb.setupThemeControls();
                 astorb.initStats();
                 astorb.loadAstorbData();
             }
@@ -1450,6 +1457,51 @@ astorb.setupOrbitLabelControls = function()
     }
 
     astorb.refreshOrbitLabelControls();
+};
+
+astorb.applyTheme = function()
+{
+    var body = document.body;
+    if (!body) return;
+
+    if (astorb.isDarkTheme)
+    {
+        body.classList.add('dark-theme');
+    }
+    else
+    {
+        body.classList.remove('dark-theme');
+    }
+
+    var themeButton = document.getElementById('themeToggleButton');
+    if (themeButton)
+    {
+        themeButton.textContent = "Theme: " + (astorb.isDarkTheme ? "Dark" : "Light");
+    }
+};
+
+astorb.setupThemeControls = function()
+{
+    var themeButton = document.getElementById('themeToggleButton');
+    if (!themeButton) return;
+
+    var storedTheme = localStorage.getItem('astorb-theme');
+    if (storedTheme)
+    {
+        astorb.isDarkTheme = storedTheme === 'dark';
+    }
+    else if (window.matchMedia)
+    {
+        astorb.isDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+
+    themeButton.addEventListener('click', function() {
+        astorb.isDarkTheme = !astorb.isDarkTheme;
+        astorb.applyTheme();
+        localStorage.setItem('astorb-theme', astorb.isDarkTheme ? 'dark' : 'light');
+    });
+
+    astorb.applyTheme();
 };
 
 astorb.stats = null;


### PR DESCRIPTION
### Motivation

- Provide a light/dark theme switch so the UI is usable in low-light environments and matches system preferences.

### Description

- Introduce CSS variables in `:root` and a `body.dark-theme` rule, and apply them across `astorb3d.html` to control colors for page background, panels, buttons, status, canvas and log.
- Add a `Theme: Light` toggle button (`#themeToggleButton`) to the control bar in `astorb3d.html`.
- Implement theme state and controls in `scripts/js/astorb3d.js` by adding `astorb.isDarkTheme`, `astorb.applyTheme()`, and `astorb.setupThemeControls()` which reads/writes `localStorage` and honors `prefers-color-scheme`.
- Make log output theme-aware by resolving black log text to a light color in dark mode so entries remain legible.

### Testing

- Served the site with `python -m http.server 8000` to exercise the page (server started successfully). 
- Attempted automated UI checks with Playwright to click `#themeToggleButton` and capture screenshots, but the Playwright runs timed out or failed to find the page/selector (timeouts/404).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf7338e7883298b41968acce03b9d)