### PR TITLE
Add cinematic & surprise controls, accessibility polish, loader hardening, and utility tests

### DIFF
--- a/astorb3d.html
+++ b/astorb3d.html
@@ -199,7 +199,9 @@
                 align-items: center;
                 padding: 6px 0;
                 flex: 0 0 auto;
-                transition: max-height 0.2s ease, opacity 0.2s ease;
+                transition:
+                    max-height 0.2s ease,
+                    opacity 0.2s ease;
             }
             #controlBar button {
                 background-color: var(--button-bg);
@@ -264,6 +266,18 @@
             #astorbLog font[color="black"] {
                 color: var(--panel-text);
             }
+            #shortcutHelp {
+                flex: 0 0 auto;
+                font-size: 12px;
+                color: var(--panel-text);
+                background: var(--panel-bg);
+                border: 1px solid var(--button-border);
+                border-radius: 6px;
+                padding: 4px 8px;
+            }
+            #shortcutHelp p {
+                margin: 4px 0;
+            }
         </style>
     </head>
     <body onload="astorb.onLoadBody()">
@@ -287,6 +301,8 @@
                 <button id="pointSizeButton" type="button">Point Size: 2px</button>
                 <button id="orbitLabelButton" type="button">Labels: Off</button>
                 <button id="themeToggleButton" type="button">Theme: Light</button>
+                <button id="cinematicModeButton" type="button">Cinematic: Off</button>
+                <button id="surpriseButton" type="button">Surprise Me</button>
                 <span id="timeScaleLabel">Speed: --</span>
             </div>
         </div>
@@ -312,12 +328,18 @@
                 </div>
             </div>
         </div>
-        <div id="statusDisplay">Status: Loading...</div>
+        <div id="statusDisplay" role="status" aria-live="polite">Status: Loading...</div>
+        <details id="shortcutHelp">
+            <summary>Keyboard & touch help</summary>
+            <p>Space pause/resume · ↑/↓ speed · 0 reset · C toggle cinematic · R randomize vibe</p>
+            <p>Drag to orbit camera, scroll/pinch to zoom.</p>
+        </details>
         <div id="astorbLog"></div>
         <!-- <script src="scripts/js/libs/sylvester.src.js"></script> -->
         <!-- <script src="scripts/js/libs/glUtils.js"></script> -->
         <script src="scripts/js/libs/gl-matrix-min.js"></script>
         <script src="scripts/js/libs/stats.min.js"></script>
+        <script src="scripts/js/astorb-utils.js"></script>
         <script src="scripts/js/astorb3d.js"></script>
         <!-- GPU shader programs embedded in the page for easy inspection. -->
         <script type="x-shader/x-vertex" id="shader-vs">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "node --test",
         "screenshot": "node tools/capture-screenshot.js",
         "lint": "eslint .",
         "format": "prettier --write .",

--- a/scripts/js/astorb-utils.js
+++ b/scripts/js/astorb-utils.js
@@ -1,0 +1,106 @@
+(function (root, factory)
+{
+    if (typeof module === "object" && module.exports)
+    {
+        module.exports = factory();
+    }
+    else
+    {
+        root.astorbUtils = factory();
+    }
+})(typeof self !== "undefined" ? self : this, function ()
+{
+    var formatNumber = function (value)
+    {
+        if (value === null || value === undefined)
+        {
+            return "--";
+        }
+        return Number(value).toLocaleString("en-US");
+    };
+
+    var formatAsteroidPercent = function (current, total)
+    {
+        if (!total)
+        {
+            return "0%";
+        }
+        var percent = (current / total) * 100;
+        return percent.toFixed(1) + "%";
+    };
+
+    var formatBytes = function (bytes)
+    {
+        if (bytes === null || bytes === undefined || isNaN(bytes))
+        {
+            return "--";
+        }
+        if (bytes === 0)
+        {
+            return "0 B";
+        }
+        var units = ["B", "KB", "MB", "GB", "TB"];
+        var index = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+        var value = bytes / Math.pow(1024, index);
+        return value.toFixed(value >= 10 || index === 0 ? 0 : 1) + " " + units[index];
+    };
+
+    var formatBitsPerSecond = function (bitsPerSecond)
+    {
+        if (!bitsPerSecond || !isFinite(bitsPerSecond))
+        {
+            return "--";
+        }
+        var units = ["bps", "Kbps", "Mbps", "Gbps"];
+        var index = Math.min(
+            units.length - 1,
+            Math.floor(Math.log(bitsPerSecond) / Math.log(1000))
+        );
+        var value = bitsPerSecond / Math.pow(1000, index);
+        return value.toFixed(value >= 10 || index === 0 ? 0 : 1) + " " + units[index];
+    };
+
+    var clamp = function (value, min, max)
+    {
+        return Math.max(min, Math.min(max, value));
+    };
+
+    var buildStatusText = function (input)
+    {
+        var safe = input || {};
+        var years = Number(safe.simTime || 0) / (365.25 * 24 * 3600);
+        var pauseStatus = safe.paused ? "[PAUSED]" : "[RUNNING]";
+        var directionLabel = safe.timeScale >= 0 ? "Forward" : "Reverse";
+        var asteroidCount = safe.asteroidCount || 0;
+        var asteroidDrawCount = safe.asteroidDrawCount || 0;
+        var percent = formatAsteroidPercent(asteroidDrawCount, asteroidCount);
+
+        return (
+            pauseStatus +
+            " Time: " +
+            years.toFixed(2) +
+            " years | " +
+            "Asteroids: " +
+            formatNumber(asteroidDrawCount) +
+            " / " +
+            formatNumber(asteroidCount) +
+            " (" +
+            percent +
+            ") | " +
+            "Speed: " +
+            Math.abs(Number(safe.timeScale || 0)).toExponential(1) +
+            "x (" +
+            directionLabel +
+            ")"
+        );
+    };
+
+    return {
+        formatNumber: formatNumber,
+        formatAsteroidPercent: formatAsteroidPercent,
+        formatBytes: formatBytes,
+        formatBitsPerSecond: formatBitsPerSecond,
+        clamp: clamp,
+        buildStatusText: buildStatusText,
+    };
+});

--- a/scripts/js/astorb3d.js
+++ b/scripts/js/astorb3d.js
@@ -17,53 +17,35 @@
 var astorb = astorb || {};
 
 // UI formatting helpers for log output and status HUDs.
-astorb.formatNumber = function (value)
-{
-    if (value === null || value === undefined)
+astorb.utils = window.astorbUtils || {};
+astorb.formatNumber =
+    astorb.utils.formatNumber ||
+    function (value)
     {
-        return "--";
-    }
-    return Number(value).toLocaleString("en-US");
-};
-
-astorb.formatAsteroidPercent = function (current, total)
-{
-    if (!total)
+        return value === null || value === undefined ? "--" : String(value);
+    };
+astorb.formatAsteroidPercent =
+    astorb.utils.formatAsteroidPercent ||
+    function (current, total)
     {
-        return "0%";
-    }
-    var percent = (current / total) * 100;
-    return percent.toFixed(1) + "%";
-};
-
-astorb.formatBytes = function (bytes)
-{
-    if (bytes === null || bytes === undefined || isNaN(bytes))
+        if (!total)
+        {
+            return "0%";
+        }
+        return ((current / total) * 100).toFixed(1) + "%";
+    };
+astorb.formatBytes =
+    astorb.utils.formatBytes ||
+    function (bytes)
     {
-        return "--";
-    }
-    if (bytes === 0)
+        return String(bytes);
+    };
+astorb.formatBitsPerSecond =
+    astorb.utils.formatBitsPerSecond ||
+    function (value)
     {
-        return "0 B";
-    }
-    var units = ["B", "KB", "MB", "GB", "TB"];
-    var index = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
-    var value = bytes / Math.pow(1024, index);
-    return value.toFixed(value >= 10 || index === 0 ? 0 : 1) + " " + units[index];
-};
-
-astorb.formatBitsPerSecond = function (bitsPerSecond)
-{
-    if (!bitsPerSecond || !isFinite(bitsPerSecond))
-    {
-        return "--";
-    }
-    var units = ["bps", "Kbps", "Mbps", "Gbps"];
-    var index = Math.min(units.length - 1, Math.floor(Math.log(bitsPerSecond) / Math.log(1000)));
-    var value = bitsPerSecond / Math.pow(1000, index);
-    return value.toFixed(value >= 10 || index === 0 ? 0 : 1) + " " + units[index];
-};
-
+        return String(value);
+    };
 // Wire up the loading overlay progress ring and numeric readouts.
 astorb.initLoadingOverlay = function ()
 {
@@ -260,6 +242,11 @@ astorb.isDarkTheme = false;
 astorb.pointSizes = [1, 2, 3, 4];
 astorb.pointSizeIndex = 1;
 astorb.pointSize = astorb.pointSizes[astorb.pointSizeIndex];
+astorb.cinematicMode = {
+    enabled: false,
+    angularVelocity: 0.11,
+    zoomAmplitude: 0.08,
+};
 astorb.onLoadBody = function ()
 {
     var canvas = document.getElementById(astorb.canvasId);
@@ -301,6 +288,8 @@ astorb.onLoadBody = function ()
                 astorb.setupPointSizeControls();
                 astorb.setupOrbitLabelControls();
                 astorb.setupThemeControls();
+                astorb.setupCinematicControls();
+                astorb.setupSurpriseControls();
                 astorb.initStats();
                 astorb.loadAstorbData();
             }
@@ -554,10 +543,22 @@ astorb.Loader = function (path, inputCallback, inputProgressCallback)
         }
     };
 
+    request.timeout = 45000;
+
     request.onprogress = function (event)
     {
         var totalBytes = event.lengthComputable ? event.total : null;
         progressCallback(event.loaded, totalBytes);
+    };
+
+    request.onerror = function ()
+    {
+        callback(request.status || 0, null);
+    };
+
+    request.ontimeout = function ()
+    {
+        callback(408, null);
     };
 
     request.send();
@@ -1529,6 +1530,16 @@ astorb.setupCameraControls = function (canvas)
                 astorb.log("Time reset to 0", "blue");
                 event.preventDefault();
                 break;
+            case "c":
+            case "C":
+                astorb.toggleCinematicMode();
+                event.preventDefault();
+                break;
+            case "r":
+            case "R":
+                astorb.activateSurpriseMode();
+                event.preventDefault();
+                break;
         }
     };
 
@@ -1816,6 +1827,11 @@ astorb.setupPointSizeControls = function ()
         {
             astorb.pointSizeIndex = (astorb.pointSizeIndex + 1) % astorb.pointSizes.length;
             astorb.pointSize = astorb.pointSizes[astorb.pointSizeIndex];
+            astorb.cinematicMode = {
+                enabled: false,
+                angularVelocity: 0.11,
+                zoomAmplitude: 0.08,
+            };
             astorb.applyPointSize();
             astorb.refreshPointSizeControls();
         });
@@ -1892,6 +1908,69 @@ astorb.setupThemeControls = function ()
     });
 
     astorb.applyTheme();
+};
+
+astorb.toggleCinematicMode = function ()
+{
+    astorb.cinematicMode.enabled = !astorb.cinematicMode.enabled;
+    astorb.refreshCinematicControls();
+    astorb.log("Cinematic mode " + (astorb.cinematicMode.enabled ? "enabled" : "disabled"), "blue");
+};
+
+astorb.setupCinematicControls = function ()
+{
+    var cinematicButton = document.getElementById("cinematicModeButton");
+    if (!cinematicButton) return;
+
+    cinematicButton.addEventListener("click", function ()
+    {
+        astorb.toggleCinematicMode();
+    });
+
+    astorb.refreshCinematicControls();
+};
+
+astorb.refreshCinematicControls = function ()
+{
+    var cinematicButton = document.getElementById("cinematicModeButton");
+    if (cinematicButton)
+    {
+        cinematicButton.textContent = "Cinematic: " + (astorb.cinematicMode.enabled ? "On" : "Off");
+    }
+};
+
+astorb.activateSurpriseMode = function ()
+{
+    astorb.colorModeIndex = Math.floor(Math.random() * astorb.colorModes.length);
+    astorb.pointSizeIndex = Math.floor(Math.random() * astorb.pointSizes.length);
+    astorb.pointSize = astorb.pointSizes[astorb.pointSizeIndex];
+    astorb.showOrbitLabels = Math.random() > 0.5;
+    astorb.motionBlur.enabled = Math.random() > 0.5;
+    astorb.time.timeScale = (Math.random() > 0.25 ? 1 : -1) * (5e4 + Math.random() * 2.5e6);
+
+    astorb.applyColorMode();
+    astorb.applyPointSize();
+    astorb.refreshRenderColorControls();
+    astorb.refreshPointSizeControls();
+    astorb.refreshOrbitLabelControls();
+    astorb.refreshMotionBlurControls();
+    astorb.refreshTimeControls();
+
+    astorb.log(
+        "Surprise mode: randomized render style, motion blur, labels, and time speed.",
+        "green"
+    );
+};
+
+astorb.setupSurpriseControls = function ()
+{
+    var surpriseButton = document.getElementById("surpriseButton");
+    if (!surpriseButton) return;
+
+    surpriseButton.addEventListener("click", function ()
+    {
+        astorb.activateSurpriseMode();
+    });
 };
 
 astorb.stats = null;
@@ -2169,6 +2248,20 @@ astorb.animate = function (timestamp)
         time.simTime += simDelta;
     }
 
+    if (astorb.cinematicMode.enabled)
+    {
+        astorb.camera.azimuth += deltaTime * astorb.cinematicMode.angularVelocity;
+        var baseDistance = 12.0;
+        var zoomWave = Math.sin(timestamp * 0.0004) * astorb.cinematicMode.zoomAmplitude;
+        astorb.camera.distance = astorb.utils.clamp
+            ? astorb.utils.clamp(
+                  baseDistance * (1 + zoomWave),
+                  astorb.camera.minDistance,
+                  astorb.camera.maxDistance
+              )
+            : astorb.camera.distance;
+    }
+
     // Update time uniform
     gl.useProgram(astorb.asteroidProgram);
     gl.uniform1f(astorb.timeUniform, time.simTime);
@@ -2185,27 +2278,15 @@ astorb.animate = function (timestamp)
         var statusDiv = document.getElementById("statusDisplay");
         if (statusDiv)
         {
-            var years = time.simTime / (365.25 * 24 * 3600); // Convert seconds to years
-            var pauseStatus = time.paused ? "[PAUSED]" : "[RUNNING]";
-            var directionLabel = time.timeScale >= 0 ? "Forward" : "Reverse";
-            var percent = astorb.formatAsteroidPercent(asteroidDrawCount, asteroidCount);
-            statusDiv.innerHTML =
-                pauseStatus +
-                " Time: " +
-                years.toFixed(2) +
-                " years | " +
-                "Asteroids: " +
-                astorb.formatNumber(asteroidDrawCount) +
-                " / " +
-                astorb.formatNumber(asteroidCount) +
-                " (" +
-                percent +
-                ") | " +
-                "Speed: " +
-                Math.abs(time.timeScale).toExponential(1) +
-                "x (" +
-                directionLabel +
-                ")";
+            statusDiv.textContent = astorb.utils.buildStatusText
+                ? astorb.utils.buildStatusText({
+                      simTime: time.simTime,
+                      paused: time.paused,
+                      timeScale: time.timeScale,
+                      asteroidCount: asteroidCount,
+                      asteroidDrawCount: asteroidDrawCount,
+                  })
+                : "Status: Running";
         }
     }
 

--- a/tests/astorb-utils.test.mjs
+++ b/tests/astorb-utils.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const utils = require("../scripts/js/astorb-utils.js");
+
+test("formatBytes handles common sizes", () =>
+{
+    assert.equal(utils.formatBytes(0), "0 B");
+    assert.equal(utils.formatBytes(1024), "1.0 KB");
+    assert.equal(utils.formatBytes(1048576), "1.0 MB");
+});
+
+test("formatAsteroidPercent handles empty and non-empty totals", () =>
+{
+    assert.equal(utils.formatAsteroidPercent(5, 0), "0%");
+    assert.equal(utils.formatAsteroidPercent(50, 200), "25.0%");
+});
+
+test("buildStatusText includes key simulation fields", () =>
+{
+    const status = utils.buildStatusText({
+        simTime: 365.25 * 24 * 3600,
+        paused: false,
+        timeScale: -200000,
+        asteroidCount: 200,
+        asteroidDrawCount: 100,
+    });
+
+    assert.match(status, /\[RUNNING\]/);
+    assert.match(status, /Time: 1\.00 years/);
+    assert.match(status, /Asteroids: 100 \/ 200 \(50\.0%\)/);
+    assert.match(status, /Reverse/);
+});


### PR DESCRIPTION
### Motivation
- Make the orbital simulator more fun and discoverable by adding playful interaction modes and keyboard shortcuts. 
- Improve accessibility and status reporting so the UI is clearer to screen readers and keyboard users. 
- Harden network loading and centralize formatting helpers to improve reliability and maintainability. 

### Description
- Added UI buttons (`Cinematic: Off`, `Surprise Me`) to the control bar, keyboard shortcuts (`C` toggles cinematic, `R` triggers surprise), and wired them into the main setup flow in `astorb3d.html` and `scripts/js/astorb3d.js`. 
- Implemented cinematic camera motion (gentle azimuth rotation and zoom wave) and a surprise mode that randomizes color mode, point size, labels, motion blur, and time scale. 
- Extracted shared formatting/clamping/status helpers into `scripts/js/astorb-utils.js` and integrated the browser code to use `astorb.utils` for status text and formatting. 
- Hardened the XHR loader with `request.timeout`, `request.onerror`, and `request.ontimeout` handlers to surface failures and avoid silent hangs. 
- Accessibility and UX polish: added an ARIA live `role="status"` `statusDisplay` and an inline `details` help panel for keyboard/touch shortcuts. 
- Added automated Node tests for the new utility module in `tests/astorb-utils.test.mjs` and updated `package.json` to run `node --test` as `npm test`; formatted files with Prettier. 

### Testing
- Ran the test suite with `npm test` (Node built-in test runner) which passed all tests (`3` tests passed). 
- Ran lint with `npm run lint` (ESLint) which completed without errors. 
- Ran formatting with `npx prettier --write` on modified files which completed successfully. 
- Performed an automated headless validation that loaded the updated page and captured a screenshot with Playwright (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984fdde63f48329b9df9c8a7d677faf)